### PR TITLE
Prepare release 3.0.1 and adopt template 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ input-cache
 .settings/*
 target/*
 .mvn/wrapper/maven-wrapper.jar
+
+/translations/*

--- a/expansion-params.json
+++ b/expansion-params.json
@@ -1,0 +1,14 @@
+{
+    "resourceType": "Parameters",
+    "id": "expansion-params",
+    "parameter": [
+        {
+            "name": "system-version",
+            "valueUri": "http://snomed.info/sct|http://snomed.info/sct/11000315107"
+        },
+        {
+          "name": "displayLanguage",
+          "valueCode": "fr-FR"
+        }
+    ]
+}

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -4,6 +4,7 @@
 
 * Suppression d'un backslash [12](https://github.com/ansforge/IG-fhir-cahier-de-liaison/pull/12)
 * Adoption du mode conteneur pour le workflow CI-build [13](https://github.com/ansforge/IG-fhir-cahier-de-liaison/pull/13)
+* Passage au template 2 [14](https://github.com/ansforge/IG-fhir-cahier-de-liaison/pull/14)
 
 **Release 3.0.0 de l'Implementation Guide cahier de liaison.**
 

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -1,3 +1,10 @@
+**Release 3.0.1 de l'Implementation Guide cahier de liaison.**
+
+[Modifications apportées dans cette release](https://github.com/ansforge/IG-fhir-cahier-de-liaison/milestone/2?closed=1) :
+
+* Suppression d'un backslash [12](https://github.com/ansforge/IG-fhir-cahier-de-liaison/pull/12)
+* Adoption du mode conteneur pour le workflow CI-build [13](https://github.com/ansforge/IG-fhir-cahier-de-liaison/pull/13)
+
 **Release 3.0.0 de l'Implementation Guide cahier de liaison.**
 
 [Modifications apportées dans cette release](https://github.com/ansforge/IG-fhir-cahier-de-liaison/milestone/1?closed=1) :

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -5,6 +5,7 @@
 * Suppression d'un backslash [12](https://github.com/ansforge/IG-fhir-cahier-de-liaison/pull/12)
 * Adoption du mode conteneur pour le workflow CI-build [13](https://github.com/ansforge/IG-fhir-cahier-de-liaison/pull/13)
 * Passage au template 2 [14](https://github.com/ansforge/IG-fhir-cahier-de-liaison/pull/14)
+* Remplacement de la dépendance `ans.fr.nos` par `ans.fr.terminologies` [14](https://github.com/ansforge/IG-fhir-cahier-de-liaison/pull/14)
 
 **Release 3.0.0 de l'Implementation Guide cahier de liaison.**
 

--- a/input/pagecontent/translationinfo.md
+++ b/input/pagecontent/translationinfo.md
@@ -1,0 +1,1 @@
+Ce document contient les informations sur les traductions.

--- a/publication-request.json
+++ b/publication-request.json
@@ -1,12 +1,12 @@
 
 {
     "package-id" : "ans.fhir.fr.cdl",
-    "version" : "3.0.0",
-    "path" : "https://interop.esante.gouv.fr/ig/fhir/cdl/3.0.0",
+    "version" : "3.0.1",
+    "path" : "https://interop.esante.gouv.fr/ig/fhir/cdl/3.0.1",
     "mode" : "technical-correction",
     "status" : "release",
     "sequence" : "trial-use",
-    "desc" : "Publication 3.0.0 du guide d'implémentation cahier de liaison",
-    "descmd": "Publication 3.0.0 du guide d'implémentation cahier de liaison. La liste des changements est accessible ici : https://interop.esante.gouv.fr/ig/fhir/cdl/changes.html",
+    "desc" : "Publication 3.0.1 du guide d'implémentation cahier de liaison",
+    "descmd": "Publication 3.0.1 du guide d'implémentation cahier de liaison. La liste des changements est accessible ici : https://interop.esante.gouv.fr/ig/fhir/cdl/changes.html",
     "changes": "changes.html"
   }

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -35,7 +35,7 @@ parameters: #Parameters list - https://build.fhir.org/ig/FHIR/fhir-tools-ig/Code
 dependencies:
   ans.fhir.fr.annuaire: 1.0.1
   hl7.fhir.fr.core: 2.0.1
-  ans.fr.nos: latest
+  ans.fr.terminologies: latest
 
 pages:
     index.md:

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -12,7 +12,7 @@ version: 3.0.1 # shall conforms to Semantic Versioning https://fr.wiktionary.org
 fhirVersion: 4.0.1
 copyrightYear: 2020+
 releaseLabel: trial-use
-jurisdiction: urn:iso:std:iso:3166#FR "FRANCE"
+jurisdiction: urn:iso:std:iso:3166#FR "France (la)"
 
 parameters: #Parameters list - https://build.fhir.org/ig/FHIR/fhir-tools-ig/CodeSystem-ig-parameters.html
     shownav: 'true'

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -7,15 +7,30 @@ title: Cahier De Liaison
 publisher:
   name: ANS
   url: https://esante.gouv.fr
-status: draft
-version: 3.0.0 # shall conforms to Semantic Versioning https://fr.wiktionary.org/wiki/SemVer
+status: active
+version: 3.0.1 # shall conforms to Semantic Versioning https://fr.wiktionary.org/wiki/SemVer
 fhirVersion: 4.0.1
 copyrightYear: 2020+
 releaseLabel: trial-use
 jurisdiction: urn:iso:std:iso:3166#FR "FRANCE"
 
-parameters:
+parameters: #Parameters list - https://build.fhir.org/ig/FHIR/fhir-tools-ig/CodeSystem-ig-parameters.html
     shownav: 'true'
+    path-expansion-params: '../../expansion-params.json' # for using French SNOMED CT Extension
+    pin-canonicals: pin-all
+    apply-contact: true
+    logging:
+      - tx #tx: Messages describing the use of the terminology server (for debugging)
+      - html #html: Log when validating an html page (troubleshooting only - leave off)
+      - generate #generate: Log when producing an individual resource (troubleshooting only - leave off)
+      - init #init: Messages describing the start up process (for debugging)
+      - progress #progress: Overall progress messages
+    i18n-default-lang: fr # Default language
+    apply-jurisdiction: true
+    i18n-lang:
+      - en
+    translation-sources:
+      - input/translations/en
 
 dependencies:
   ans.fhir.fr.annuaire: 1.0.1
@@ -39,6 +54,8 @@ pages:
             title: Recherche d'une note
     changes.md:
         title: Historique des changements
+    translationinfo.md:
+        title: Informations sur la traduction
 
 menu:
     Accueil: index.html


### PR DESCRIPTION
## Description des changements

* `sushi-config.yaml` : version 3.0.0 → 3.0.1, status `draft` → `active` (releaseLabel reste `trial-use`) ; ajout des paramètres i18n/traduction et `path-expansion-params` pour le passage au template 2
* `publication-request.json` : version/path/desc/descmd → 3.0.1 (mode `technical-correction` conservé)
* `input/pagecontent/changes.md` : ajout de la section 3.0.1 listant les PR #12 et #13
* `expansion-params.json` (nouveau) : paramètres d'expansion requis par le template 2 (SNOMED CT FR, displayLanguage)
* `input/pagecontent/translationinfo.md` (nouveau) : page d'information sur la traduction requise par le template 2

## Passage au template 2

Suivi de https://github.com/ansforge/IG-documentation/wiki/Passage-au-template-2, calqué sur la migration minimale de `ansforge/IG-fhir-annuaire#302`. Le contenu de traduction anglaise (`input/translations/en/*.po`) est laissé en suivi séparé (traduction de contenu clinique à valider par un locuteur).

## Preview

https://ansforge.github.io/IG-fhir-cahier-de-liaison/nr-prepare-release/ig